### PR TITLE
Simplify marketing routes to default locale

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "rules": {
+    "react-hooks/exhaustive-deps": "warn"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+.DS_Store
+.env.local
+.env
+coverage

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# bonjourbonjour
-Ce projet a pour objectif de développer une plateforme innovante permettant la communication efficace avec des Médias Professionnels (MCPs). Utilisant des technologies de pointe, ce projet vise à simplifier et optimiser les interactions dans le domaine médiatique.
+# Harrison & Associés – Next.js
+
+Ce dépôt contient la base du site vitrine du cabinet Harrison & Associés. L'application est construite avec Next.js (App Router), Tailwind CSS et la librairie de composants shadcn/ui. L'expérience est livrée en français et reprend les sections de la maquette Figma dans une structure simple et responsive.
+
+## Démarrage rapide
+
+```bash
+pnpm install # ou npm install / yarn install
+pnpm dev     # lance le serveur de développement sur http://localhost:3000
+```
+
+## Principales fonctionnalités
+
+- **Next.js 14** avec App Router et TypeScript pour une architecture moderne et maintenable.
+- **UI** : Tailwind CSS, composants shadcn/ui et design responsive inspiré de la maquette Figma.
+- **Pages dédiées** : Accueil, Méthodologie, Expertise, Équipe, Fondateur, Contact avec formulaires interactifs.
+- **Expérience fluide** : navigation cohérente et formulaire de contact accessible depuis chaque page.
+- **Accessibilité & UX** : navigation mobile, interactions douces, formulaires validés côté client, notifications toast.
+
+## Structure du projet
+
+- `app/(marketing)` : layout applicatif et pages marketing accessibles directement (/, /methodology, /expertise, ...).
+- `components/` : composants UI, sections et providers (i18n, notifications).
+- `lib/i18n` : dictionnaires de contenu (fr par défaut, base pour d'éventuelles traductions).
+- `styles/globals.css` : thème Tailwind personnalisé aligné avec l'identité visuelle.
+
+## Production
+
+```bash
+pnpm build
+pnpm start
+```
+
+L'application s'ouvre directement sur la page d'accueil via http://localhost:3000.

--- a/app/(marketing)/contact/page.tsx
+++ b/app/(marketing)/contact/page.tsx
@@ -1,0 +1,8 @@
+import { ContactSection } from '@/components/sections/contact-section';
+import { defaultLocale } from '@/lib/i18n/config';
+import { getDictionarySync } from '@/lib/i18n/dictionaries';
+
+export default function ContactPage() {
+  const dictionary = getDictionarySync(defaultLocale);
+  return <ContactSection dictionary={dictionary.contact} />;
+}

--- a/app/(marketing)/expertise/page.tsx
+++ b/app/(marketing)/expertise/page.tsx
@@ -1,0 +1,8 @@
+import { ExpertiseSection } from '@/components/sections/expertise-section';
+import { defaultLocale } from '@/lib/i18n/config';
+import { getDictionarySync } from '@/lib/i18n/dictionaries';
+
+export default function ExpertisePage() {
+  const dictionary = getDictionarySync(defaultLocale);
+  return <ExpertiseSection dictionary={dictionary.expertise} />;
+}

--- a/app/(marketing)/founder/page.tsx
+++ b/app/(marketing)/founder/page.tsx
@@ -1,0 +1,8 @@
+import { FounderSection } from '@/components/sections/founder-section';
+import { defaultLocale } from '@/lib/i18n/config';
+import { getDictionarySync } from '@/lib/i18n/dictionaries';
+
+export default function FounderPage() {
+  const dictionary = getDictionarySync(defaultLocale);
+  return <FounderSection dictionary={dictionary.founder} />;
+}

--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -1,0 +1,29 @@
+import { Navigation } from '@/components/layout/navigation';
+import { Footer } from '@/components/layout/footer';
+import { DictionaryProvider } from '@/components/providers/dictionary-provider';
+import { SonnerProvider } from '@/components/providers/sonner-provider';
+import { defaultLocale } from '@/lib/i18n/config';
+import { getDictionarySync } from '@/lib/i18n/dictionaries';
+
+export default function MarketingLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  const dictionary = getDictionarySync(defaultLocale);
+
+  return (
+    <DictionaryProvider dictionary={dictionary}>
+      <div className="flex min-h-screen flex-col bg-background text-foreground">
+        <Navigation
+          links={dictionary.navigation.links}
+          cta={dictionary.navigation.cta}
+          logo={dictionary.navigation.logo}
+        />
+        <main className="flex-1">{children}</main>
+        <Footer />
+      </div>
+      <SonnerProvider />
+    </DictionaryProvider>
+  );
+}

--- a/app/(marketing)/methodology/page.tsx
+++ b/app/(marketing)/methodology/page.tsx
@@ -1,0 +1,8 @@
+import { MethodologySection } from '@/components/sections/methodology-section';
+import { defaultLocale } from '@/lib/i18n/config';
+import { getDictionarySync } from '@/lib/i18n/dictionaries';
+
+export default function MethodologyPage() {
+  const dictionary = getDictionarySync(defaultLocale);
+  return <MethodologySection dictionary={dictionary.methodology} />;
+}

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -1,0 +1,8 @@
+import { HomeSection } from '@/components/sections/home-section';
+import { defaultLocale } from '@/lib/i18n/config';
+import { getDictionarySync } from '@/lib/i18n/dictionaries';
+
+export default function Page() {
+  const dictionary = getDictionarySync(defaultLocale);
+  return <HomeSection dictionary={dictionary.home} />;
+}

--- a/app/(marketing)/team/page.tsx
+++ b/app/(marketing)/team/page.tsx
@@ -1,0 +1,8 @@
+import { TeamSection } from '@/components/sections/team-section';
+import { defaultLocale } from '@/lib/i18n/config';
+import { getDictionarySync } from '@/lib/i18n/dictionaries';
+
+export default function TeamPage() {
+  const dictionary = getDictionarySync(defaultLocale);
+  return <TeamSection dictionary={dictionary.team} />;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+import '@/styles/globals.css';
+
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
+
+export const metadata: Metadata = {
+  title: 'Harrison & Associés',
+  description: 'Cabinet de gestion de patrimoine sur-mesure.'
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="fr" suppressHydrationWarning>
+      <body className={inter.variable}>{children}</body>
+    </html>
+  );
+}

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { Mail, MapPin, Phone, Send } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { useDictionary } from '@/components/providers/dictionary-provider';
+
+export function Footer() {
+  const dictionary = useDictionary();
+  const { footer } = dictionary;
+  const [formData, setFormData] = useState({ name: '', email: '', phone: '', message: '' });
+
+  const handleChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = event.target;
+    setFormData((previous) => ({ ...previous, [name]: value }));
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    toast.success(footer.submit);
+    setFormData({ name: '', email: '', phone: '', message: '' });
+  };
+
+  return (
+    <footer id="contact-form" className="bg-primary py-16 text-white">
+      <div className="mx-auto grid max-w-7xl gap-12 px-6 lg:grid-cols-2 lg:px-8">
+        <div className="space-y-8">
+          <div>
+            <h2 className="text-3xl tracking-tight">{footer.title}</h2>
+            <p className="mt-4 max-w-xl text-lg text-gray-300">{footer.description}</p>
+          </div>
+
+          <div className="space-y-6 text-sm text-gray-300">
+            <div className="flex items-center gap-4">
+              <span className="flex h-12 w-12 items-center justify-center rounded-lg bg-accent/10">
+                <MapPin className="h-5 w-5 text-accent" />
+              </span>
+              <div>
+                <p>{footer.address}</p>
+                <p>{footer.city}</p>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-4">
+              <span className="flex h-12 w-12 items-center justify-center rounded-lg bg-accent/10">
+                <Phone className="h-5 w-5 text-accent" />
+              </span>
+              <div>
+                <p>{footer.phoneLabel}</p>
+                <p>{footer.phoneAvailability}</p>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-4">
+              <span className="flex h-12 w-12 items-center justify-center rounded-lg bg-accent/10">
+                <Mail className="h-5 w-5 text-accent" />
+              </span>
+              <div>
+                <p>{footer.emailLabel}</p>
+                <p>{footer.emailAvailability}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-2xl bg-white/10 p-8 backdrop-blur">
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            <div>
+              <h3 className="text-xl">{footer.formTitle}</h3>
+            </div>
+            <Input
+              name="name"
+              placeholder={footer.name}
+              value={formData.name}
+              onChange={handleChange}
+              required
+              className="border-white/20 bg-white/10 text-white placeholder:text-gray-300 focus:border-accent focus:ring-accent/50"
+            />
+            <Input
+              type="email"
+              name="email"
+              placeholder={footer.email}
+              value={formData.email}
+              onChange={handleChange}
+              required
+              className="border-white/20 bg-white/10 text-white placeholder:text-gray-300 focus:border-accent focus:ring-accent/50"
+            />
+            <Input
+              name="phone"
+              placeholder={footer.phone}
+              value={formData.phone}
+              onChange={handleChange}
+              className="border-white/20 bg-white/10 text-white placeholder:text-gray-300 focus:border-accent focus:ring-accent/50"
+            />
+            <Textarea
+              name="message"
+              placeholder={footer.messagePlaceholder}
+              value={formData.message}
+              onChange={handleChange}
+              rows={4}
+              required
+              className="border-white/20 bg-white/10 text-white placeholder:text-gray-300 focus:border-accent focus:ring-accent/50"
+            />
+            <Button type="submit" className="w-full bg-accent text-white hover:bg-accent/90">
+              <Send className="mr-2 h-4 w-4" />
+              {footer.submit}
+            </Button>
+          </form>
+        </div>
+      </div>
+
+      <div className="mt-12 border-t border-white/10 pt-8 text-center text-sm text-gray-300">
+        {footer.copyright}
+      </div>
+    </footer>
+  );
+}

--- a/components/layout/navigation.tsx
+++ b/components/layout/navigation.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { Menu, X } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useState } from 'react';
+
+import type { NavigationLink } from '@/lib/i18n/dictionaries';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export function Navigation({
+  links,
+  cta,
+  logo
+}: {
+  links: NavigationLink[];
+  cta: string;
+  logo: { primary: string; secondary: string };
+}) {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  const toggleMenu = () => setOpen((state) => !state);
+
+  const isActive = (href: string) => pathname === href;
+
+  return (
+    <nav className="sticky top-0 z-50 border-b border-border/40 bg-white/95 backdrop-blur">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-6 lg:px-8">
+        <Link href="/" className="flex items-center gap-3" prefetch={false}>
+          <span className="h-8 w-2 bg-wood" aria-hidden />
+          <span>
+            <span className="block text-2xl tracking-widest text-primary">{logo.primary}</span>
+            <span className="mt-1 block text-xs tracking-[0.3em] text-gray-500">
+              {logo.secondary}
+            </span>
+          </span>
+        </Link>
+
+        <div className="hidden items-center gap-10 md:flex">
+          {links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={cn(
+                'text-sm uppercase tracking-[0.2em] text-gray-500 transition-colors hover:text-primary',
+                isActive(link.href) && 'text-primary'
+              )}
+              prefetch={false}
+            >
+              {link.label}
+            </Link>
+          ))}
+          <Button asChild className="px-6 py-2 text-sm uppercase tracking-[0.2em]">
+            <Link href="/contact" prefetch={false}>
+              {cta}
+            </Link>
+          </Button>
+        </div>
+
+        <button
+          type="button"
+          onClick={toggleMenu}
+          className="inline-flex items-center justify-center rounded-md p-2 text-gray-600 transition-colors hover:text-primary md:hidden"
+          aria-label="Toggle menu"
+        >
+          {open ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+        </button>
+      </div>
+
+      {open ? (
+        <div className="border-t border-border/40 bg-white md:hidden">
+          <div className="space-y-2 px-6 py-6">
+            {links.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => setOpen(false)}
+                className={cn(
+                  'block rounded-md px-3 py-2 text-sm uppercase tracking-[0.2em] text-gray-600 transition-colors hover:bg-gray-100 hover:text-primary',
+                  isActive(link.href) && 'text-primary'
+                )}
+                prefetch={false}
+              >
+                {link.label}
+              </Link>
+            ))}
+            <Button className="w-full" asChild>
+              <Link href="/contact" prefetch={false}>
+                {cta}
+              </Link>
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </nav>
+  );
+}

--- a/components/providers/dictionary-provider.tsx
+++ b/components/providers/dictionary-provider.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import type { Dictionary } from '@/lib/i18n/dictionaries';
+
+const DictionaryContext = createContext<Dictionary | null>(null);
+
+export function DictionaryProvider({
+  dictionary,
+  children
+}: {
+  dictionary: Dictionary;
+  children: React.ReactNode;
+}) {
+  return (
+    <DictionaryContext.Provider value={dictionary}>
+      {children}
+    </DictionaryContext.Provider>
+  );
+}
+
+export function useDictionary() {
+  const context = useContext(DictionaryContext);
+
+  if (!context) {
+    throw new Error('useDictionary must be used within a DictionaryProvider');
+  }
+
+  return context;
+}

--- a/components/providers/sonner-provider.tsx
+++ b/components/providers/sonner-provider.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { Toaster } from 'sonner';
+
+export function SonnerProvider() {
+  return <Toaster position="top-center" richColors />;
+}

--- a/components/sections/contact-section.tsx
+++ b/components/sections/contact-section.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import { Calendar, Check, Clock, Mail, MapPin, Phone } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import type { Dictionary } from '@/lib/i18n/dictionaries';
+
+export function ContactSection({ dictionary }: { dictionary: Dictionary['contact'] }) {
+  const [selectedDate, setSelectedDate] = useState<string>('');
+  const [selectedTime, setSelectedTime] = useState<string>('');
+  const [submitted, setSubmitted] = useState(false);
+  const slots = useMemo(() => ['09:00', '10:00', '11:00', '14:00', '15:00', '16:00'], []);
+  const dates = useMemo(
+    () => [
+      'Lundi 2 Décembre',
+      'Mardi 3 Décembre',
+      'Mercredi 4 Décembre',
+      'Jeudi 5 Décembre',
+      'Vendredi 6 Décembre'
+    ],
+    []
+  );
+
+  if (submitted) {
+    return (
+      <div className="bg-gray-50/50 py-24">
+        <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
+          <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-green-50">
+            <Check className="h-10 w-10 text-green-600" />
+          </div>
+          <h1 className="mt-8 text-4xl text-primary">
+            {dictionary.form.confirmation.title.map((line) => (
+              <span key={line} className="block">
+                {line}
+              </span>
+            ))}
+          </h1>
+          <p className="mt-6 text-lg text-gray-600">{dictionary.form.confirmation.description}</p>
+
+          <div className="mt-12 space-y-4 text-left">
+            <p className="text-sm uppercase tracking-[0.3em] text-gray-500">
+              {dictionary.form.confirmation.nextStepsTitle}
+            </p>
+            <div className="space-y-4">
+              {dictionary.form.confirmation.steps.map((step) => (
+                <div key={step.title} className="rounded-xl bg-white p-4 shadow-sm">
+                  <p className="font-medium text-primary">{step.title}</p>
+                  <p className="text-sm text-gray-600">{step.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <Button asChild className="mt-12 bg-primary px-8 py-3 text-white hover:bg-wood">
+            <a href="/">{dictionary.form.confirmation.backHome}</a>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white py-20">
+      <div className="mx-auto max-w-6xl px-6 lg:px-8">
+        <div className="grid gap-16 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="space-y-10">
+            <div>
+              <p className="text-sm uppercase tracking-[0.3em] text-gray-500">
+                {dictionary.hero.eyebrow}
+              </p>
+              <h1 className="mt-4 text-4xl text-primary">
+                {dictionary.hero.title.map((line) => (
+                  <span key={line} className="block">
+                    {line}
+                  </span>
+                ))}
+              </h1>
+              <p className="mt-6 text-xl text-gray-600">{dictionary.hero.description}</p>
+            </div>
+
+            <div className="space-y-6">
+              <div className="flex items-start gap-4">
+                <Clock className="mt-1 h-5 w-5 text-wood" />
+                <div>
+                  <p className="font-medium text-primary">{dictionary.info.duration.title}</p>
+                  <p className="text-sm text-gray-600">{dictionary.info.duration.description}</p>
+                </div>
+              </div>
+              <div className="flex items-start gap-4">
+                <MapPin className="mt-1 h-5 w-5 text-wood" />
+                <div>
+                  <p className="font-medium text-primary">{dictionary.info.location.title}</p>
+                  <p className="text-sm text-gray-600">{dictionary.info.location.description}</p>
+                </div>
+              </div>
+              <div className="flex items-start gap-4">
+                <Mail className="mt-1 h-5 w-5 text-wood" />
+                <div>
+                  <p className="font-medium text-primary">{dictionary.info.confidentiality.title}</p>
+                  <p className="text-sm text-gray-600">{dictionary.info.confidentiality.description}</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-3 text-gray-600">
+              <div className="flex items-center gap-3">
+                <Phone className="h-5 w-5 text-wood" />
+                <span>{dictionary.info.details.phone}</span>
+              </div>
+              <div className="flex items-center gap-3">
+                <Mail className="h-5 w-5 text-wood" />
+                <span>{dictionary.info.details.email}</span>
+              </div>
+              <div className="flex items-center gap-3">
+                <MapPin className="h-5 w-5 text-wood" />
+                <span>{dictionary.info.details.address}</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-2xl bg-gray-50/60 p-8">
+            <form
+              className="space-y-8"
+              onSubmit={(event) => {
+                event.preventDefault();
+                if (!selectedDate || !selectedTime) return;
+                setSubmitted(true);
+              }}
+            >
+              <div className="space-y-4">
+                <h3 className="text-xl text-primary">{dictionary.form.personalTitle}</h3>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div>
+                    <label className="mb-2 block text-xs uppercase tracking-[0.3em] text-gray-600">
+                      {dictionary.form.fields.firstName}
+                    </label>
+                    <Input required className="bg-white" />
+                  </div>
+                  <div>
+                    <label className="mb-2 block text-xs uppercase tracking-[0.3em] text-gray-600">
+                      {dictionary.form.fields.lastName}
+                    </label>
+                    <Input required className="bg-white" />
+                  </div>
+                </div>
+                <div>
+                  <label className="mb-2 block text-xs uppercase tracking-[0.3em] text-gray-600">
+                    {dictionary.form.fields.email}
+                  </label>
+                  <Input type="email" required className="bg-white" />
+                </div>
+                <div>
+                  <label className="mb-2 block text-xs uppercase tracking-[0.3em] text-gray-600">
+                    {dictionary.form.fields.phone}
+                  </label>
+                  <Input className="bg-white" />
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <h3 className="text-xl text-primary">{dictionary.form.availabilityTitle}</h3>
+                <div>
+                  <p className="mb-2 text-xs uppercase tracking-[0.3em] text-gray-600">
+                    {dictionary.form.dateLabel}
+                  </p>
+                  <div className="grid gap-3">
+                    {dates.map((date) => (
+                      <button
+                        type="button"
+                        key={date}
+                        onClick={() => setSelectedDate(date)}
+                        className={`rounded-lg border px-4 py-3 text-left transition ${
+                          selectedDate === date
+                            ? 'border-wood bg-wood/10 text-primary'
+                            : 'border-gray-200 text-gray-700 hover:border-wood/40'
+                        }`}
+                      >
+                        {date}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {selectedDate ? (
+                  <div>
+                    <p className="mb-2 text-xs uppercase tracking-[0.3em] text-gray-600">
+                      {dictionary.form.timeLabel}
+                    </p>
+                    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                      {slots.map((slot) => (
+                        <button
+                          type="button"
+                          key={slot}
+                          onClick={() => setSelectedTime(slot)}
+                          className={`rounded-lg border px-4 py-3 text-center transition ${
+                            selectedTime === slot
+                              ? 'border-wood bg-wood/10 text-primary'
+                              : 'border-gray-200 text-gray-700 hover:border-wood/40'
+                          }`}
+                        >
+                          {slot}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+
+              <div>
+                <label className="mb-2 block text-xs uppercase tracking-[0.3em] text-gray-600">
+                  {dictionary.form.fields.wealthObjectives}
+                </label>
+                <Textarea
+                  rows={4}
+                  placeholder={dictionary.form.fields.objectivePlaceholder}
+                  className="bg-white"
+                />
+              </div>
+
+              <Button
+                type="submit"
+                disabled={!selectedDate || !selectedTime}
+                className="w-full bg-primary py-4 text-white hover:bg-wood disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <Calendar className="mr-2 h-5 w-5" />
+                {dictionary.form.submit}
+              </Button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/sections/expertise-section.tsx
+++ b/components/sections/expertise-section.tsx
@@ -1,0 +1,83 @@
+import { Building, FileText, TrendingUp, Umbrella } from 'lucide-react';
+
+import type { Dictionary } from '@/lib/i18n/dictionaries';
+
+const icons = [TrendingUp, Building, FileText, Umbrella];
+
+export function ExpertiseSection({ dictionary }: { dictionary: Dictionary['expertise'] }) {
+  return (
+    <div className="bg-white py-20">
+      <div className="mx-auto max-w-6xl px-6 lg:px-8">
+        <div className="mb-16 text-center">
+          <h1 className="text-4xl font-light text-primary sm:text-5xl">
+            {dictionary.hero.title.map((line) => (
+              <span key={line} className="block">
+                {line}
+              </span>
+            ))}
+          </h1>
+          <p className="mt-6 text-lg text-gray-600">{dictionary.hero.description}</p>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-2">
+          {dictionary.areas.map((area, index) => {
+            const Icon = icons[index] ?? TrendingUp;
+            return (
+              <div
+                key={area.title}
+                className="group h-full rounded-2xl border border-gray-100 bg-white p-8 shadow-lg transition hover:border-accent/30 hover:shadow-xl"
+              >
+                <div className="mb-6 flex items-center gap-4">
+                  <span className="flex h-16 w-16 items-center justify-center rounded-2xl bg-accent/10 transition group-hover:bg-accent/20">
+                    <Icon className="h-8 w-8 text-accent" />
+                  </span>
+                  <h3 className="text-2xl text-primary group-hover:text-accent">{area.title}</h3>
+                </div>
+                <p className="text-gray-600">{area.description}</p>
+                <div className="mt-6">
+                  <h4 className="font-medium text-primary">{dictionary.featuresLabel}</h4>
+                  <ul className="mt-4 space-y-3 text-gray-600">
+                    {area.features.map((feature) => (
+                      <li key={feature} className="flex items-start gap-3">
+                        <span className="mt-2 h-2 w-2 rounded-full bg-accent" />
+                        <span>{feature}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-20 rounded-2xl bg-primary p-12 text-white">
+          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
+            {dictionary.stats.map((stat) => (
+              <div key={stat.label} className="text-center">
+                <div className="text-4xl font-medium">{stat.value}</div>
+                <p className="mt-2 text-gray-300">{stat.label}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-16 rounded-2xl bg-secondary/40 p-12 text-center">
+          <h2 className="text-3xl font-light text-primary">
+            {dictionary.cta.title.map((line) => (
+              <span key={line} className="block">
+                {line}
+              </span>
+            ))}
+          </h2>
+          <p className="mt-6 text-lg text-gray-600">{dictionary.cta.description}</p>
+          <a
+            href="#contact-form"
+            className="mt-8 inline-flex items-center justify-center rounded-lg bg-accent px-8 py-4 text-lg text-white transition hover:bg-accent/90"
+          >
+            {dictionary.cta.button}
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/sections/founder-section.tsx
+++ b/components/sections/founder-section.tsx
@@ -1,0 +1,155 @@
+import { ArrowLeft, Award, Building, GraduationCap, Users } from 'lucide-react';
+import Link from 'next/link';
+
+import type { Dictionary } from '@/lib/i18n/dictionaries';
+
+export function FounderSection({
+  dictionary
+}: {
+  dictionary: Dictionary['founder'];
+}) {
+  return (
+    <div className="bg-white py-20">
+      <div className="mx-auto max-w-6xl px-6 lg:px-8">
+        <Link
+          href="/"
+          className="mb-12 inline-flex items-center gap-3 text-sm uppercase tracking-[0.2em] text-gray-500 transition hover:text-primary"
+        >
+          <ArrowLeft className="h-5 w-5" />
+          Retour
+        </Link>
+
+        <section className="grid gap-16 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+          <div className="space-y-8">
+            <div>
+              <p className="text-sm uppercase tracking-[0.3em] text-gray-500">
+                {dictionary.hero.eyebrow}
+              </p>
+              <h1 className="mt-6 text-5xl font-light text-primary">
+                {dictionary.hero.title.map((line) => (
+                  <span key={line} className="block">
+                    {line}
+                  </span>
+                ))}
+              </h1>
+            </div>
+            <p className="text-xl text-gray-600">{dictionary.hero.summary}</p>
+            <div className="space-y-4 text-gray-600">
+              {dictionary.hero.paragraphs.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </div>
+          </div>
+          <div className="relative aspect-[3/4] rounded-2xl bg-gradient-to-br from-gray-100 to-gray-200">
+            <div className="absolute inset-0 flex items-center justify-center">
+              <div className="text-center text-gray-500">
+                <Users className="mx-auto mb-4 h-16 w-16 opacity-50" />
+                <span className="text-sm uppercase tracking-[0.3em]">Portrait professionnel</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mt-20 bg-gray-50/60 py-16">
+          <div className="mx-auto max-w-4xl space-y-12">
+            <div className="text-center">
+              <p className="text-sm uppercase tracking-[0.3em] text-gray-500">
+                {dictionary.experience.eyebrow}
+              </p>
+              <h2 className="mt-4 text-3xl text-primary">
+                {dictionary.experience.title.map((line) => (
+                  <span key={line} className="block">
+                    {line}
+                  </span>
+                ))}
+              </h2>
+            </div>
+            <div className="space-y-10">
+              {dictionary.experience.entries.map((entry, index) => {
+                const icons = [Building, Award, Users, GraduationCap];
+                const Icon = icons[index] ?? Building;
+                return (
+                  <div key={entry.title} className="flex gap-6">
+                    <span className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-wood/10 text-wood">
+                      <Icon className="h-6 w-6" />
+                    </span>
+                    <div>
+                      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                        <h3 className="text-xl text-primary">{entry.title}</h3>
+                        <span className="text-sm uppercase tracking-[0.2em] text-gray-500">
+                          {entry.period}
+                        </span>
+                      </div>
+                      <p className="text-wood">{entry.company}</p>
+                      <p className="mt-2 text-gray-600">{entry.description}</p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section className="mt-20 grid gap-16 lg:grid-cols-2">
+          <div className="space-y-8">
+            <div>
+              <p className="text-sm uppercase tracking-[0.3em] text-gray-500">
+                {dictionary.philosophy.eyebrow}
+              </p>
+              <h2 className="mt-4 text-3xl text-primary">
+                {dictionary.philosophy.title.map((line) => (
+                  <span key={line} className="block">
+                    {line}
+                  </span>
+                ))}
+              </h2>
+            </div>
+            <div className="space-y-6 text-gray-600">
+              {dictionary.philosophy.quotes.map((quote) => (
+                <blockquote key={quote} className="border-l-4 border-wood pl-6 text-lg italic text-primary">
+                  {quote}
+                </blockquote>
+              ))}
+            </div>
+          </div>
+          <div className="space-y-8">
+            <div className="rounded-2xl bg-gray-50 p-8">
+              <h3 className="text-xl text-primary">{dictionary.philosophy.certifications.title}</h3>
+              <ul className="mt-4 space-y-3 text-gray-600">
+                {dictionary.philosophy.certifications.items.map((item) => (
+                  <li key={item.name} className="flex items-center justify-between">
+                    <span>{item.name}</span>
+                    <span className="text-sm text-gray-500">{item.detail}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="rounded-2xl bg-primary/5 p-8">
+              <h3 className="text-xl text-primary">{dictionary.philosophy.engagement.title}</h3>
+              <p className="mt-3 text-gray-600">
+                {dictionary.philosophy.engagement.description}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="mt-20 rounded-2xl bg-primary p-12 text-center text-white">
+          <h2 className="text-3xl font-light">
+            {dictionary.cta.title.map((line) => (
+              <span key={line} className="block">
+                {line}
+              </span>
+            ))}
+          </h2>
+          <p className="mt-6 text-lg text-gray-300">{dictionary.cta.description}</p>
+          <Link
+            href="/contact"
+            className="mt-8 inline-flex items-center justify-center rounded-lg bg-accent px-8 py-4 text-lg text-white transition hover:bg-accent/90"
+          >
+            {dictionary.cta.button}
+          </Link>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/components/sections/home-section.tsx
+++ b/components/sections/home-section.tsx
@@ -1,0 +1,115 @@
+import Link from 'next/link';
+import { ArrowRight, Shield, TrendingUp, Users } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import type { Dictionary } from '@/lib/i18n/dictionaries';
+
+export function HomeSection({
+  dictionary
+}: {
+  dictionary: Dictionary['home'];
+}) {
+  return (
+    <div className="flex flex-col">
+      <section className="relative overflow-hidden bg-gradient-to-br from-secondary via-white to-secondary/50 py-24 lg:py-32">
+        <div className="absolute inset-0 bg-gradient-to-r from-wood-light/5 to-wood/10" aria-hidden />
+        <div className="relative z-10 mx-auto max-w-5xl px-6 text-center lg:px-8">
+          <p className="mb-6 text-sm uppercase tracking-[0.4em] text-gray-500">
+            {dictionary.hero.eyebrow}
+          </p>
+          <h1 className="text-4xl font-light tracking-tight text-primary sm:text-5xl lg:text-7xl">
+            {dictionary.hero.title.map((line) => (
+              <span key={line} className="block">
+                {line}
+              </span>
+            ))}
+          </h1>
+          <p className="mt-6 text-lg font-light text-gray-600 sm:text-xl lg:text-2xl">
+            {dictionary.hero.description}
+          </p>
+          <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Button
+              size="lg"
+              className="bg-accent px-8 py-4 text-lg text-white hover:bg-accent/90"
+              asChild
+            >
+              <Link href="/contact">{dictionary.hero.primaryCta}</Link>
+            </Button>
+            <Button
+              size="lg"
+              variant="outline"
+              className="border-primary px-8 py-4 text-lg text-primary hover:bg-primary hover:text-primary-foreground"
+              asChild
+            >
+              <Link href="/methodology">{dictionary.hero.secondaryCta}</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-white py-16 sm:py-20">
+        <div className="mx-auto max-w-6xl px-6 lg:px-8">
+          <div className="grid gap-12 sm:grid-cols-3">
+            {dictionary.stats.map((stat, index) => {
+              const icons = [Shield, TrendingUp, Users];
+              const Icon = icons[index] ?? Shield;
+              return (
+                <div key={stat.label} className="text-center">
+                  <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-accent/10">
+                    <Icon className="h-8 w-8 text-accent" />
+                  </div>
+                  <div className="text-4xl text-primary">{stat.value}</div>
+                  <p className="mt-2 text-lg text-gray-600">{stat.label}</p>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-secondary/30 py-20">
+        <div className="mx-auto max-w-6xl px-6 lg:px-8">
+          <div className="mb-16 text-center">
+            <h2 className="text-3xl font-light text-primary sm:text-4xl">
+              {dictionary.hero.emphasis}
+            </h2>
+          </div>
+          <div className="grid gap-8 lg:grid-cols-3">
+            {dictionary.values.map((value) => (
+              <div
+                key={value.title}
+                className="rounded-2xl border border-wood-light/20 bg-white p-8 shadow-sm transition-shadow hover:shadow-lg"
+              >
+                <h3 className="text-2xl text-primary">{value.title}</h3>
+                <p className="mt-4 text-gray-600">{value.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-primary py-20 text-white">
+        <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
+          <h2 className="text-3xl font-light sm:text-4xl">
+            {dictionary.trust.title.map((line) => (
+              <span key={line} className="block">
+                {line}
+              </span>
+            ))}
+          </h2>
+          <p className="mt-6 text-lg text-gray-300">{dictionary.trust.description}</p>
+          <Button
+            size="lg"
+            className="mt-8 bg-accent px-8 py-4 text-lg text-white hover:bg-accent/90"
+            asChild
+          >
+            <Link href="/contact">
+              {dictionary.trust.button}
+              <ArrowRight className="ml-2 inline-block h-5 w-5" />
+            </Link>
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/sections/methodology-section.tsx
+++ b/components/sections/methodology-section.tsx
@@ -1,0 +1,87 @@
+import { Monitor, Search, Target } from 'lucide-react';
+
+import type { Dictionary } from '@/lib/i18n/dictionaries';
+
+const icons = [Search, Target, Monitor];
+
+export function MethodologySection({ dictionary }: { dictionary: Dictionary['methodology'] }) {
+  return (
+    <div className="bg-gray-50/40 py-20">
+      <div className="mx-auto max-w-5xl px-6 lg:px-8">
+        <div className="mb-16 text-center">
+          <h1 className="text-4xl font-light text-primary sm:text-5xl">
+            {dictionary.hero.title.map((line) => (
+              <span key={line} className="block">
+                {line}
+              </span>
+            ))}
+          </h1>
+          <p className="mt-6 text-lg text-gray-600">{dictionary.hero.description}</p>
+        </div>
+
+        <div className="relative">
+          <div className="hidden h-full w-px -translate-x-1/2 transform bg-gray-200 lg:absolute lg:left-1/2 lg:block" />
+          <div className="space-y-16 lg:space-y-24">
+            {dictionary.steps.map((step, index) => {
+              const Icon = icons[index] ?? Search;
+              const isEven = index % 2 === 0;
+              return (
+                <div
+                  key={step.title}
+                  className="flex flex-col gap-10 lg:grid lg:grid-cols-2 lg:items-center"
+                >
+                  <div className={isEven ? '' : 'lg:col-start-2'}>
+                    <div className="rounded-2xl bg-white p-8 shadow-lg">
+                      <div className="mb-6 flex items-center gap-4">
+                        <span className="flex h-16 w-16 items-center justify-center rounded-2xl bg-accent/10">
+                          <Icon className="h-8 w-8 text-accent" />
+                        </span>
+                        <div>
+                          <p className="text-sm uppercase tracking-[0.3em] text-accent">
+                            {dictionary.stepLabel} {index + 1}
+                          </p>
+                          <h3 className="text-2xl text-primary">{step.title}</h3>
+                        </div>
+                      </div>
+                      <p className="text-gray-600">{step.description}</p>
+                      <ul className="mt-6 space-y-3 text-gray-600">
+                        {step.details.map((detail) => (
+                          <li key={detail} className="flex items-start gap-3">
+                            <span className="mt-2 h-2 w-2 rounded-full bg-accent" />
+                            <span>{detail}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                  <div className="hidden lg:block">
+                    <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-accent text-white">
+                      {index + 1}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="mt-20 rounded-2xl bg-secondary/40 p-12 text-center">
+          <h2 className="text-3xl font-light text-primary">
+            {dictionary.cta.title.map((line) => (
+              <span key={line} className="block">
+                {line}
+              </span>
+            ))}
+          </h2>
+          <p className="mt-6 text-lg text-gray-600">{dictionary.cta.description}</p>
+          <a
+            href="#contact-form"
+            className="mt-8 inline-flex items-center justify-center rounded-lg bg-accent px-8 py-4 text-lg text-white transition-colors hover:bg-accent/90"
+          >
+            {dictionary.cta.button}
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/sections/team-section.tsx
+++ b/components/sections/team-section.tsx
@@ -1,0 +1,94 @@
+import { Award, BookOpen, Globe, Shield } from 'lucide-react';
+
+import type { Dictionary } from '@/lib/i18n/dictionaries';
+
+const icons = [Award, BookOpen, Shield, Globe];
+
+export function TeamSection({ dictionary }: { dictionary: Dictionary['team'] }) {
+  return (
+    <div className="bg-gray-50/40 py-20">
+      <div className="mx-auto max-w-6xl px-6 lg:px-8">
+        <div className="mb-16 text-center">
+          <h1 className="text-4xl font-light text-primary sm:text-5xl">
+            {dictionary.hero.title.map((line) => (
+              <span key={line} className="block">
+                {line}
+              </span>
+            ))}
+          </h1>
+          <p className="mt-6 text-lg text-gray-600">{dictionary.hero.description}</p>
+        </div>
+
+        <div className="grid gap-16 lg:grid-cols-2 lg:items-center">
+          <div className="space-y-6">
+            <h2 className="text-4xl text-primary">
+              {dictionary.founder.name}
+            </h2>
+            <p className="text-accent">{dictionary.founder.role}</p>
+            <div className="space-y-4 text-gray-600">
+              {dictionary.founder.biography.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {dictionary.founder.highlights.map((highlight) => (
+                <span
+                  key={highlight}
+                  className="rounded-full bg-accent/10 px-3 py-1 text-sm text-accent"
+                >
+                  {highlight}
+                </span>
+              ))}
+            </div>
+          </div>
+          <div className="grid gap-8 sm:grid-cols-2">
+            {dictionary.achievements.map((achievement, index) => {
+              const Icon = icons[index] ?? Award;
+              return (
+                <div
+                  key={achievement.title}
+                  className="rounded-2xl border border-gray-100 bg-white p-6 text-center shadow-sm"
+                >
+                  <span className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-wood/10">
+                    <Icon className="h-8 w-8 text-wood" />
+                  </span>
+                  <h3 className="text-xl text-primary">{achievement.title}</h3>
+                  <p className="mt-3 text-sm text-gray-600">{achievement.description}</p>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="mt-20 rounded-2xl bg-white p-12 shadow-lg">
+          <h2 className="text-3xl text-primary">{dictionary.valuesHeading}</h2>
+          <div className="mt-8 grid gap-8 lg:grid-cols-3">
+            {dictionary.values.map((value) => (
+              <div key={value.title} className="text-center">
+                <h3 className="text-2xl text-primary">{value.title}</h3>
+                <p className="mt-4 text-gray-600">{value.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-16 rounded-2xl bg-primary p-12 text-center text-white">
+          <h2 className="text-3xl font-light">
+            {dictionary.cta.title.map((line) => (
+              <span key={line} className="block">
+                {line}
+              </span>
+            ))}
+          </h2>
+          <p className="mt-6 text-lg text-gray-300">{dictionary.cta.description}</p>
+          <a
+            href="#contact-form"
+            className="mt-8 inline-flex items-center justify-center rounded-lg bg-accent px-8 py-4 text-lg text-white transition hover:bg-accent/90"
+          >
+            {dictionary.cta.button}
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-wood',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        outline:
+          'border border-primary text-primary bg-transparent hover:bg-primary hover:text-primary-foreground',
+        ghost: 'hover:bg-primary/10 hover:text-primary',
+        link: 'text-primary underline-offset-4 hover:underline'
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10'
+      }
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default'
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-11 w-full rounded-md border border-border bg-input px-4 py-3 text-base transition-colors placeholder:text-muted-foreground focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = 'Input';
+
+export { Input };

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        'flex w-full rounded-md border border-border bg-input px-4 py-3 text-base transition-colors placeholder:text-muted-foreground focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = 'Textarea';
+
+export { Textarea };

--- a/lib/i18n/config.ts
+++ b/lib/i18n/config.ts
@@ -1,0 +1,3 @@
+export const locales = ['fr', 'en'] as const;
+export type Locale = (typeof locales)[number];
+export const defaultLocale: Locale = 'fr';

--- a/lib/i18n/dictionaries.ts
+++ b/lib/i18n/dictionaries.ts
@@ -1,0 +1,1028 @@
+import type { Locale } from './config';
+
+export type NavigationLink = {
+  href: string;
+  label: string;
+};
+
+export type Dictionary = {
+  metadata: {
+    title: string;
+    description: string;
+  };
+  navigation: {
+    logo: {
+      primary: string;
+      secondary: string;
+    };
+    links: NavigationLink[];
+    cta: string;
+  };
+  home: {
+    hero: {
+      eyebrow: string;
+      title: string[];
+      emphasis: string;
+      description: string;
+      primaryCta: string;
+      secondaryCta: string;
+    };
+    stats: {
+      value: string;
+      label: string;
+    }[];
+    values: {
+      title: string;
+      description: string;
+    }[];
+    trust: {
+      title: string;
+      description: string;
+      button: string;
+    };
+  };
+  methodology: {
+    hero: {
+      title: string[];
+      description: string;
+    };
+    stepLabel: string;
+    steps: {
+      title: string;
+      description: string;
+      details: string[];
+    }[];
+    cta: {
+      title: string[];
+      description: string;
+      button: string;
+    };
+  };
+  expertise: {
+    hero: {
+      title: string[];
+      description: string;
+    };
+    featuresLabel: string;
+    areas: {
+      title: string;
+      description: string;
+      features: string[];
+    }[];
+    stats: {
+      value: string;
+      label: string;
+    }[];
+    cta: {
+      title: string[];
+      description: string;
+      button: string;
+    };
+  };
+  team: {
+    hero: {
+      title: string[];
+      description: string;
+    };
+    valuesHeading: string;
+    founder: {
+      name: string;
+      role: string;
+      biography: string[];
+      highlights: string[];
+    };
+    achievements: {
+      title: string;
+      description: string;
+    }[];
+    values: {
+      title: string;
+      description: string;
+    }[];
+    cta: {
+      title: string[];
+      description: string;
+      button: string;
+    };
+  };
+  founder: {
+    hero: {
+      eyebrow: string;
+      title: string[];
+      summary: string;
+      paragraphs: string[];
+    };
+    experience: {
+      eyebrow: string;
+      title: string[];
+      entries: {
+        period: string;
+        title: string;
+        company: string;
+        description: string;
+      }[];
+    };
+    philosophy: {
+      eyebrow: string;
+      title: string[];
+      quotes: string[];
+      certifications: {
+        title: string;
+        items: {
+          name: string;
+          detail: string;
+        }[];
+      };
+      engagement: {
+        title: string;
+        description: string;
+      };
+    };
+    cta: {
+      title: string[];
+      description: string;
+      button: string;
+    };
+  };
+  contact: {
+    hero: {
+      eyebrow: string;
+      title: string[];
+      description: string;
+    };
+    info: {
+      duration: {
+        title: string;
+        description: string;
+      };
+      location: {
+        title: string;
+        description: string;
+      };
+      confidentiality: {
+        title: string;
+        description: string;
+      };
+      details: {
+        phone: string;
+        email: string;
+        address: string;
+      };
+    };
+    form: {
+      heading: string;
+      personalTitle: string;
+      fields: {
+        firstName: string;
+        lastName: string;
+        email: string;
+        phone: string;
+        wealthObjectives: string;
+        objectivePlaceholder: string;
+      };
+      availabilityTitle: string;
+      dateLabel: string;
+      timeLabel: string;
+      submit: string;
+      confirmation: {
+        title: string[];
+        description: string;
+        nextStepsTitle: string;
+        steps: {
+          title: string;
+          description: string;
+        }[];
+        backHome: string;
+      };
+    };
+  };
+  footer: {
+    title: string;
+    description: string;
+    address: string;
+    city: string;
+    phoneLabel: string;
+    phoneAvailability: string;
+    emailLabel: string;
+    emailAvailability: string;
+    formTitle: string;
+    name: string;
+    email: string;
+    phone: string;
+    message: string;
+    messagePlaceholder: string;
+    submit: string;
+    copyright: string;
+  };
+};
+
+const fr: Dictionary = {
+  metadata: {
+    title: 'Harrison & Associés',
+    description:
+      "Cabinet indépendant de gestion de patrimoine dédié aux familles et entrepreneurs exigeants."
+  },
+  navigation: {
+    logo: {
+      primary: 'HARRISON',
+      secondary: '& ASSOCIÉS'
+    },
+    links: [
+      { href: '/', label: 'Accueil' },
+      { href: '/methodology', label: 'Méthodologie' },
+      { href: '/expertise', label: "Expertise" },
+      { href: '/team', label: 'Équipe' },
+      { href: '/founder', label: 'Fondateur' },
+      { href: '/contact', label: 'Contact' }
+    ],
+    cta: 'Prendre rendez-vous'
+  },
+  home: {
+    hero: {
+      eyebrow: 'Gestion de Patrimoine',
+      title: ['Protéger, développer et transmettre', 'votre patrimoine.'],
+      emphasis: 'Votre patrimoine mérite une stratégie sur-mesure.',
+      description:
+        "Une approche traditionnelle et éprouvée de la gestion de patrimoine, au service des familles et entrepreneurs exigeants.",
+      primaryCta: 'Planifier une consultation',
+      secondaryCta: 'Découvrir notre approche'
+    },
+    stats: [
+      { value: '15+', label: "Années d'expérience" },
+      { value: '12%', label: 'Croissance annuelle moyenne' },
+      { value: '50+', label: 'Familles accompagnées' }
+    ],
+    values: [
+      {
+        title: 'Indépendance',
+        description:
+          "Nous fournissons des conseils impartiaux et transparents, libres de tout conflit d'intérêts."
+      },
+      {
+        title: 'Performance',
+        description:
+          "Une gestion disciplinée et active pour optimiser le rendement ajusté au risque de vos actifs."
+      },
+      {
+        title: 'Confidentialité',
+        description:
+          "Nos standards de discrétion garantissent la confidentialité absolue de vos informations."
+      }
+    ],
+    trust: {
+      title: ['Prêts à sécuriser votre avenir financier ?'],
+      description:
+        "Planifions une consultation confidentielle pour analyser vos objectifs patrimoniaux et définir les stratégies adaptées.",
+      button: 'Planifier une consultation'
+    }
+  },
+  methodology: {
+    hero: {
+      title: ['Notre méthodologie éprouvée'],
+      description:
+        "Un processus structuré et rigoureux pour comprendre votre situation, concevoir une stratégie personnalisée et l'ajuster dans la durée."
+    },
+    stepLabel: 'Étape',
+    steps: [
+      {
+        title: 'Diagnostic complet',
+        description:
+          'Analyse approfondie de votre situation financière, de vos objectifs et de votre environnement familial.',
+        details: [
+          'Audit patrimonial complet et identification des objectifs',
+          'Profil de risque et cartographie des enjeux familiaux',
+          'Analyse de la structure patrimoniale existante',
+          'Évaluation des stratégies financières en place'
+        ]
+      },
+      {
+        title: 'Planification stratégique',
+        description:
+          'Élaboration d’une stratégie sur-mesure alignée sur vos ambitions et votre horizon temporel.',
+        details: [
+          'Construction de la stratégie d’investissement personnalisée',
+          'Optimisation fiscale et préparation successorale',
+          'Gestion des risques et couverture assurantielle',
+          'Organisation de la transmission intergénérationnelle'
+        ]
+      },
+      {
+        title: 'Suivi continu',
+        description:
+          'Pilotage et ajustements réguliers pour préserver la performance et la conformité de votre patrimoine.',
+        details: [
+          'Rebalancement et optimisation périodique des portefeuilles',
+          'Revues de performance trimestrielles et reporting détaillé',
+          'Ajustements proactifs en fonction des marchés',
+          'Communication continue et transparente'
+        ]
+      }
+    ],
+    cta: {
+      title: ['Expérimentez notre processus'],
+      description:
+        'Réservez une consultation personnalisée pour bénéficier d’un accompagnement structuré et discret.',
+      button: 'Démarrer votre accompagnement'
+    }
+  },
+  expertise: {
+    hero: {
+      title: ['Nos expertises'],
+      description:
+        "Des compétences spécialisées couvrant l'ensemble des problématiques patrimoniales des familles fortunées."
+    },
+    featuresLabel: 'Services clés',
+    areas: [
+      {
+        title: 'Gestion financière',
+        description:
+          'Allocation d’actifs sophistiquée sur les marchés cotés et non cotés pour optimiser la performance.',
+        features: [
+          'Construction et optimisation des portefeuilles',
+          'Accès à des fonds privés et alternatifs',
+          'Stratégies d’investissement responsables et ESG',
+          'Gestion du risque et protection du capital',
+          'Optimisation du rendement ajusté au risque'
+        ]
+      },
+      {
+        title: 'Structuration immobilière',
+        description:
+          'Structuration et financement d’investissements immobiliers résidentiels et commerciaux internationaux.',
+        features: [
+          'Stratégies d’acquisition internationales',
+          'Création de structures de détention adaptées',
+          'Analyse d’opportunités et due diligence',
+          'Développement immobilier commercial',
+          'Accompagnement sur les actifs résidentiels de prestige'
+        ]
+      },
+      {
+        title: 'Fiscalité & transmission',
+        description:
+          'Anticipation et optimisation des enjeux fiscaux et successoraux pour préserver votre héritage.',
+        features: [
+          'Structuration juridique et fiscale internationale',
+          'Mise en place de trusts et fondations',
+          'Planification successorale multi-juridictionnelle',
+          'Transmission des entreprises familiales',
+          'Stratégies de philanthropie et de mécénat'
+        ]
+      },
+      {
+        title: 'Retraite & protection',
+        description:
+          'Préparation de la retraite et couverture des risques pour assurer la pérennité du patrimoine.',
+        features: [
+          'Plans de retraite pour dirigeants et cadres',
+          'Audit des couvertures assurantielles',
+          'Préparation à la dépendance et à la prévoyance',
+          'Optimisation des pensions et indemnités',
+          'Protection du patrimoine familial'
+        ]
+      }
+    ],
+    stats: [
+      { value: '8,5%', label: 'Performance annuelle moyenne' },
+      { value: '€5M+', label: 'Patrimoine client moyen' },
+      { value: '3', label: "Pays d'intervention" },
+      { value: '100%', label: 'Clients satisfaits' }
+    ],
+    cta: {
+      title: ['Découvrez comment notre expertise peut vous accompagner'],
+      description:
+        'Planifions un entretien pour analyser vos besoins spécifiques et bâtir une feuille de route patrimoniale.',
+      button: 'Échanger avec un expert'
+    }
+  },
+  team: {
+    hero: {
+      title: ['Rencontrez votre conseiller'],
+      description:
+        'Une équipe expérimentée qui comprend les enjeux de la gestion de patrimoine transgénérationnelle.'
+    },
+    valuesHeading: 'Nos valeurs',
+    founder: {
+      name: 'Michael Harrison',
+      role: 'Fondateur & Conseiller principal',
+      biography: [
+        "Fort de 15 années d'expérience en gestion de patrimoine et banque privée, Michael a fondé Harrison & Associés pour offrir des conseils véritablement indépendants.",
+        "Il a exercé au sein d’institutions financières de premier plan où il a développé une expertise reconnue en structuration patrimoniale et gestion d’actifs sophistiqués.",
+        'Diplômé d’une grande école de commerce et titulaire de la certification CFA, il incarne les plus hauts standards fiduciaires.'
+      ],
+      highlights: ['CFA Charter', 'MBA Wharton', '15+ ans de carrière', 'Standard fiduciaire']
+    },
+    achievements: [
+      {
+        title: '15+ années d’expérience',
+        description:
+          'Direction d’équipes de gestion de patrimoine au sein d’institutions internationales de premier plan.'
+      },
+      {
+        title: 'Formation d’excellence',
+        description:
+          'Diplômes de grandes écoles de commerce, certification CFA et formation continue spécialisée.'
+      },
+      {
+        title: 'Standard fiduciaire',
+        description:
+          'Engagement d’agir dans l’intérêt exclusif des clients avec transparence totale.'
+      },
+      {
+        title: 'Vision internationale',
+        description:
+          'Expérience en Europe, en Amérique du Nord et sur les marchés émergents.'
+      }
+    ],
+    values: [
+      {
+        title: 'Confidentialité',
+        description:
+          'La discrétion absolue et la sécurité des informations clients guident chacune de nos décisions.'
+      },
+      {
+        title: 'Indépendance',
+        description:
+          'Une liberté totale dans le choix des solutions recommandées, sans contraintes commerciales.'
+      },
+      {
+        title: 'Performance',
+        description:
+          'Une recherche constante de rendement ajusté au risque, avec une vision long terme.'
+      }
+    ],
+    cta: {
+      title: ['Prêts à travailler ensemble ?'],
+      description:
+        'Découvrez la différence d’un accompagnement indépendant et personnalisé pour votre patrimoine.',
+      button: 'Planifier un entretien'
+    }
+  },
+  founder: {
+    hero: {
+      eyebrow: 'Fondateur & Directeur',
+      title: ['James Harrison'],
+      summary:
+        "Expert en gestion de patrimoine avec plus de 15 années d'expérience auprès des familles patrimoniales européennes.",
+      paragraphs: [
+        'Diplômé de HEC Paris et titulaire du CFA, James Harrison a évolué au sein de banques de premier plan avant de créer Harrison & Associés.',
+        'Son ambition : proposer un accompagnement réellement indépendant et hautement confidentiel pour les familles et entrepreneurs fortunés.'
+      ]
+    },
+    experience: {
+      eyebrow: 'Parcours professionnel',
+      title: ['Une expertise reconnue'],
+      entries: [
+        {
+          period: '2020 - Présent',
+          title: 'Fondateur & Directeur',
+          company: 'Harrison & Associés',
+          description:
+            'Création et développement du cabinet indépendant. Accompagnement sur-mesure des familles patrimoniales.'
+        },
+        {
+          period: '2015 - 2020',
+          title: 'Directeur adjoint gestion privée',
+          company: 'Rothschild & Co Wealth Management',
+          description:
+            'Management d’une équipe de 12 conseillers et accompagnement des clients UHNWI et family offices.'
+        },
+        {
+          period: '2010 - 2015',
+          title: 'Conseiller patrimonial senior',
+          company: 'BNP Paribas Wealth Management',
+          description:
+            'Développement d’un portefeuille patrimonial et expertise en structuration fiscale internationale.'
+        },
+        {
+          period: '2008 - 2010',
+          title: 'Analyste financier',
+          company: 'Crédit Suisse',
+          description:
+            'Sélection d’investissements pour la clientèle privée et formation aux métiers de la gestion de fortune.'
+        }
+      ]
+    },
+    philosophy: {
+      eyebrow: 'Vision & philosophie',
+      title: ["L'indépendance au service de l'excellence"],
+      quotes: [
+        '« La gestion de patrimoine commence par la compréhension des enjeux familiaux et personnels. Chaque situation mérite une approche sur-mesure. »',
+        '« Notre indépendance nous permet de recommander les meilleures solutions du marché, dans l’intérêt exclusif de nos clients. »'
+      ],
+      certifications: {
+        title: 'Certifications & formations',
+        items: [
+          { name: 'HEC Paris', detail: 'MBA Finance' },
+          { name: 'CFA Institute', detail: 'Chartered Financial Analyst' },
+          { name: 'CAIA Association', detail: 'Alternative Investment Analyst' },
+          { name: 'AGEFI', detail: 'Expert fiscal certifié' }
+        ]
+      },
+      engagement: {
+        title: 'Engagement personnel',
+        description:
+          'Membre du conseil d’administration de la Fondation pour l’Enfance et mécène d’initiatives culturelles.'
+      }
+    },
+    cta: {
+      title: ['Échanger directement'],
+      description:
+        'Une conversation confidentielle pour comprendre vos enjeux patrimoniaux et bâtir un plan d’action.',
+      button: 'Prendre rendez-vous'
+    }
+  },
+  contact: {
+    hero: {
+      eyebrow: 'Prise de rendez-vous',
+      title: ['Planifions notre rencontre'],
+      description:
+        'Un premier entretien confidentiel pour comprendre vos objectifs patrimoniaux et envisager les meilleures stratégies.'
+    },
+    info: {
+      duration: {
+        title: 'Durée : 45 minutes',
+        description: 'Le temps nécessaire pour une analyse approfondie et structurée.'
+      },
+      location: {
+        title: 'Au bureau ou à distance',
+        description: 'Rencontre à Paris 8 ou visioconférence selon vos préférences.'
+      },
+      confidentiality: {
+        title: 'Confidentialité garantie',
+        description: 'Respect absolu du secret professionnel et sécurité des échanges.'
+      },
+      details: {
+        phone: '+33 1 42 00 00 00',
+        email: 'contact@harrison-associes.com',
+        address: '128 Avenue des Champs-Élysées, 75008 Paris'
+      }
+    },
+    form: {
+      heading: 'Votre demande',
+      personalTitle: 'Vos informations',
+      fields: {
+        firstName: 'Prénom',
+        lastName: 'Nom',
+        email: 'Email',
+        phone: 'Téléphone',
+        wealthObjectives: 'Objectifs patrimoniaux (optionnel)',
+        objectivePlaceholder: 'Partagez vos priorités ou préoccupations principales...'
+      },
+      availabilityTitle: 'Créneaux disponibles',
+      dateLabel: 'Date souhaitée',
+      timeLabel: 'Horaire préféré',
+      submit: 'Confirmer le rendez-vous',
+      confirmation: {
+        title: ['Demande confirmée'],
+        description:
+          'Votre demande de rendez-vous a bien été transmise. Nous revenons vers vous sous 24 heures pour confirmer le créneau choisi.',
+        nextStepsTitle: 'Prochaines étapes',
+        steps: [
+          {
+            title: 'Confirmation sous 24h',
+            description: 'Un membre de notre équipe valide avec vous la date et l’horaire.'
+          },
+          {
+            title: 'Préparation personnalisée',
+            description: 'Nous rassemblons la documentation adaptée à vos objectifs.'
+          },
+          {
+            title: 'Entretien confidentiel',
+            description: 'Analyse approfondie de votre situation patrimoniale.'
+          }
+        ],
+        backHome: "Retour à l'accueil"
+      }
+    }
+  },
+  footer: {
+    title: 'Entrons en contact',
+    description:
+      'Protégons, développons et transmettons votre patrimoine grâce à un accompagnement discret et indépendant.',
+    address: '123 Financial District',
+    city: 'New York, NY 10005',
+    phoneLabel: '+1 (555) 123-4567',
+    phoneAvailability: 'Du lundi au vendredi, 9h - 18h',
+    emailLabel: 'contact@wealthadvisory.com',
+    emailAvailability: 'Réponse sous 24 heures',
+    formTitle: 'Demander une consultation',
+    name: 'Nom complet',
+    email: 'Adresse email',
+    phone: 'Téléphone',
+    message: 'Message',
+    messagePlaceholder: 'Parlez-nous de vos objectifs patrimoniaux...',
+    submit: 'Être recontacté',
+    copyright:
+      '© 2024 Harrison & Associés. Tous droits réservés. | Confidentiel et propriétaire.'
+  }
+};
+
+const en: Dictionary = {
+  metadata: {
+    title: 'Harrison & Associates',
+    description:
+      'Independent wealth management for families and entrepreneurs seeking bespoke strategies.'
+  },
+  navigation: {
+    logo: {
+      primary: 'HARRISON',
+      secondary: '& ASSOCIATES'
+    },
+    links: [
+      { href: '/', label: 'Home' },
+      { href: '/methodology', label: 'Methodology' },
+      { href: '/expertise', label: 'Expertise' },
+      { href: '/team', label: 'Team' },
+      { href: '/founder', label: 'Founder' },
+      { href: '/contact', label: 'Contact' }
+    ],
+    cta: 'Book a consultation'
+  },
+  home: {
+    hero: {
+      eyebrow: 'Wealth Management',
+      title: ['Protecting, growing and passing on', 'your wealth.'],
+      emphasis: 'Your wealth deserves a bespoke strategy.',
+      description:
+        'A traditional and proven approach to wealth management for discerning families and entrepreneurs.',
+      primaryCta: 'Book a consultation',
+      secondaryCta: 'Learn more'
+    },
+    stats: [
+      { value: '15+', label: 'Years of experience' },
+      { value: '12%', label: 'Average portfolio growth' },
+      { value: '50+', label: 'Family offices served' }
+    ],
+    values: [
+      {
+        title: 'Independence',
+        description:
+          'Advice free from conflicts of interest or product sales pressures, focused on your priorities.'
+      },
+      {
+        title: 'Performance',
+        description:
+          'Disciplined, active management designed to maximize risk-adjusted returns across cycles.'
+      },
+      {
+        title: 'Confidentiality',
+        description:
+          'Absolute discretion and secure processes to protect your personal and financial information.'
+      }
+    ],
+    trust: {
+      title: ['Ready to secure your financial future?'],
+      description:
+        'Schedule a confidential consultation to assess your objectives and craft the right strategies.',
+      button: 'Schedule consultation'
+    }
+  },
+  methodology: {
+    hero: {
+      title: ['Our proven methodology'],
+      description:
+        'A disciplined three-step process to understand, design and continuously refine your wealth strategy.'
+    },
+    stepLabel: 'Step',
+    steps: [
+      {
+        title: 'Comprehensive diagnosis',
+        description:
+          'We start with a detailed review of your financial situation, objectives and family dynamics.',
+        details: [
+          'Full wealth audit and goal identification',
+          'Risk profiling and family governance review',
+          'Assessment of your current structures',
+          'Evaluation of existing financial strategies'
+        ]
+      },
+      {
+        title: 'Strategic planning',
+        description:
+          'We craft a bespoke strategy aligned with your ambitions, timelines and constraints.',
+        details: [
+          'Tailored investment strategy design',
+          'Tax optimization and estate planning',
+          'Risk management and insurance review',
+          'Multi-generational succession planning'
+        ]
+      },
+      {
+        title: 'Ongoing monitoring',
+        description:
+          'We actively monitor, report and adjust to preserve performance and relevance over time.',
+        details: [
+          'Regular portfolio rebalancing and optimization',
+          'Quarterly reporting and review meetings',
+          'Proactive adjustments in line with markets',
+          'Continuous, transparent communication'
+        ]
+      }
+    ],
+    cta: {
+      title: ['Experience our process'],
+      description:
+        'Book a personalized consultation and discover how our methodology delivers lasting results.',
+      button: 'Start your journey'
+    }
+  },
+  expertise: {
+    hero: {
+      title: ['Our expertise'],
+      description:
+        'Specialized capabilities covering every dimension of complex multi-jurisdictional wealth.'
+    },
+    featuresLabel: 'Key services',
+    areas: [
+      {
+        title: 'Financial management',
+        description:
+          'Sophisticated asset allocation across public and private markets to optimize performance.',
+        features: [
+          'Portfolio construction and optimization',
+          'Private equity and alternative access',
+          'ESG and impact investing strategies',
+          'Risk mitigation and capital protection',
+          'Maximizing risk-adjusted returns'
+        ]
+      },
+      {
+        title: 'Real estate structuring',
+        description:
+          'Strategic structuring and financing for global residential and commercial investments.',
+        features: [
+          'International acquisition strategies',
+          'Tailored holding structures',
+          'Opportunity analysis and due diligence',
+          'Commercial development advisory',
+          'Support with prime residential assets'
+        ]
+      },
+      {
+        title: 'Tax & succession planning',
+        description:
+          'Anticipating and optimizing tax and inheritance considerations to protect your legacy.',
+        features: [
+          'International tax and legal structuring',
+          'Trust and foundation establishment',
+          'Cross-border succession planning',
+          'Family business transition strategies',
+          'Philanthropy and charitable planning'
+        ]
+      },
+      {
+        title: 'Retirement & protection',
+        description:
+          'Preparing for retirement and safeguarding against risks to preserve long-term wealth.',
+        features: [
+          'Executive retirement planning',
+          'Insurance and risk coverage audits',
+          'Long-term care and contingency planning',
+          'Pension optimization',
+          'Family wealth protection'
+        ]
+      }
+    ],
+    stats: [
+      { value: '8.5%', label: 'Average annual performance' },
+      { value: '$5M+', label: 'Average client assets' },
+      { value: '3', label: 'Countries served' },
+      { value: '100%', label: 'Client satisfaction' }
+    ],
+    cta: {
+      title: ['Discover how our expertise benefits you'],
+      description:
+        'Schedule a consultation to discuss your needs and build a roadmap tailored to your objectives.',
+      button: 'Discuss your needs'
+    }
+  },
+  team: {
+    hero: {
+      title: ['Meet your advisor'],
+      description:
+        'Seasoned professionals who understand the complexity of stewarding multi-generational wealth.'
+    },
+    valuesHeading: 'Our values',
+    founder: {
+      name: 'Michael Harrison',
+      role: 'Founder & Principal Advisor',
+      biography: [
+        'With 15 years of private banking and wealth management experience, Michael founded Harrison & Associates to provide truly independent advice.',
+        'He previously held leadership roles within leading financial institutions, developing deep expertise in structuring sophisticated wealth strategies.',
+        'An alumnus of a top business school and CFA charterholder, he upholds the highest fiduciary standards.'
+      ],
+      highlights: ['CFA Charter', 'Wharton MBA', '15+ years', 'Fiduciary standard']
+    },
+    achievements: [
+      {
+        title: '15+ years of experience',
+        description:
+          'Led wealth management teams within global institutions serving complex family needs.'
+      },
+      {
+        title: 'Academic excellence',
+        description:
+          'Top business school graduate, CFA charterholder and lifelong learner in advanced finance.'
+      },
+      {
+        title: 'Fiduciary standard',
+        description:
+          'Committed to acting solely in clients’ best interests with complete transparency.'
+      },
+      {
+        title: 'International vision',
+        description:
+          'Experience across Europe, North America and emerging markets.'
+      }
+    ],
+    values: [
+      {
+        title: 'Confidentiality',
+        description:
+          'Your privacy is paramount and protected by institutional-grade security and protocols.'
+      },
+      {
+        title: 'Independence',
+        description:
+          'Advice guided only by your objectives, not by product or distribution constraints.'
+      },
+      {
+        title: 'Performance',
+        description:
+          'A relentless focus on risk-adjusted returns with a long-term mindset.'
+      }
+    ],
+    cta: {
+      title: ['Ready to work together?'],
+      description:
+        'Experience the difference of independent, bespoke wealth management aligned with your values.',
+      button: 'Schedule a meeting'
+    }
+  },
+  founder: {
+    hero: {
+      eyebrow: 'Founder & Managing Partner',
+      title: ['James Harrison'],
+      summary:
+        'Wealth management expert with over 15 years advising European entrepreneurial families.',
+      paragraphs: [
+        'Graduate of HEC Paris and CFA charterholder, James built his career in leading banks before founding Harrison & Associates.',
+        'His mission is to deliver truly independent and discreet support for families and entrepreneurs with significant wealth.'
+      ]
+    },
+    experience: {
+      eyebrow: 'Professional journey',
+      title: ['Recognised expertise'],
+      entries: [
+        {
+          period: '2020 - Present',
+          title: 'Founder & Managing Partner',
+          company: 'Harrison & Associates',
+          description:
+            'Established and scaled an independent wealth advisory serving complex family needs.'
+        },
+        {
+          period: '2015 - 2020',
+          title: 'Deputy Head of Private Banking',
+          company: 'Rothschild & Co Wealth Management',
+          description:
+            'Led a team of 12 advisors focused on UHNWI and family office clients across Europe.'
+        },
+        {
+          period: '2010 - 2015',
+          title: 'Senior Wealth Advisor',
+          company: 'BNP Paribas Wealth Management',
+          description:
+            'Developed high-net-worth client relationships and cross-border tax strategies.'
+        },
+        {
+          period: '2008 - 2010',
+          title: 'Financial Analyst',
+          company: 'Credit Suisse',
+          description:
+            'Conducted investment selection and research for private banking clients.'
+        }
+      ]
+    },
+    philosophy: {
+      eyebrow: 'Vision & philosophy',
+      title: ['Independence in the pursuit of excellence'],
+      quotes: [
+        '“Wealth management begins with a deep understanding of family and personal priorities. Every situation requires a tailored approach.”',
+        '“Independence empowers us to recommend the best solutions in the market exclusively in our clients’ interests.”'
+      ],
+      certifications: {
+        title: 'Certifications & education',
+        items: [
+          { name: 'HEC Paris', detail: 'MBA Finance' },
+          { name: 'CFA Institute', detail: 'Chartered Financial Analyst' },
+          { name: 'CAIA Association', detail: 'Chartered Alternative Investment Analyst' },
+          { name: 'AGEFI', detail: 'Certified tax expert' }
+        ]
+      },
+      engagement: {
+        title: 'Personal commitments',
+        description:
+          'Board member of the Foundation for Children and patron of cultural initiatives.'
+      }
+    },
+    cta: {
+      title: ['Connect directly'],
+      description:
+        'Schedule a confidential conversation to explore your priorities and craft an actionable plan.',
+      button: 'Book a meeting'
+    }
+  },
+  contact: {
+    hero: {
+      eyebrow: 'Appointment request',
+      title: ['Let’s plan our meeting'],
+      description:
+        'A confidential first conversation to understand your wealth objectives and explore strategic options.'
+    },
+    info: {
+      duration: {
+        title: 'Duration: 45 minutes',
+        description: 'Sufficient time for a thorough, structured discussion.'
+      },
+      location: {
+        title: 'In-office or remote',
+        description: 'Meet in Paris 8 or via secure video conferencing.'
+      },
+      confidentiality: {
+        title: 'Confidentiality guaranteed',
+        description: 'Absolute professional secrecy and secure information handling.'
+      },
+      details: {
+        phone: '+33 1 42 00 00 00',
+        email: 'contact@harrison-associes.com',
+        address: '128 Avenue des Champs-Élysées, 75008 Paris'
+      }
+    },
+    form: {
+      heading: 'Your request',
+      personalTitle: 'Your information',
+      fields: {
+        firstName: 'First name',
+        lastName: 'Last name',
+        email: 'Email',
+        phone: 'Phone',
+        wealthObjectives: 'Wealth objectives (optional)',
+        objectivePlaceholder: 'Share your main priorities or concerns...'
+      },
+      availabilityTitle: 'Available slots',
+      dateLabel: 'Preferred date',
+      timeLabel: 'Preferred time',
+      submit: 'Confirm appointment',
+      confirmation: {
+        title: ['Request confirmed'],
+        description:
+          'Your appointment request has been received. Our team will confirm the proposed slot within 24 hours.',
+        nextStepsTitle: 'Next steps',
+        steps: [
+          {
+            title: 'Confirmation within 24h',
+            description: 'We will reach out to validate the date and time with you.'
+          },
+          {
+            title: 'Tailored preparation',
+            description: 'We prepare documentation aligned with your objectives.'
+          },
+          {
+            title: 'Confidential meeting',
+            description: 'An in-depth review of your wealth priorities.'
+          }
+        ],
+        backHome: 'Return home'
+      }
+    }
+  },
+  footer: {
+    title: 'Get in touch',
+    description:
+      'Protect, grow and transfer your wealth with independent, discreet advice tailored to your family.',
+    address: '123 Financial District',
+    city: 'New York, NY 10005',
+    phoneLabel: '+1 (555) 123-4567',
+    phoneAvailability: 'Monday - Friday, 9AM - 6PM',
+    emailLabel: 'contact@wealthadvisory.com',
+    emailAvailability: 'Response within 24 hours',
+    formTitle: 'Request a consultation',
+    name: 'Full name',
+    email: 'Email address',
+    phone: 'Phone number',
+    message: 'Message',
+    messagePlaceholder: 'Tell us about your wealth objectives...',
+    submit: 'Request a call back',
+    copyright:
+      '© 2024 Harrison & Associates. All rights reserved. | Confidential and proprietary.'
+  }
+};
+
+const dictionaries: Record<Locale, Dictionary> = {
+  fr,
+  en
+};
+
+export const getDictionarySync = (locale: Locale): Dictionary => dictionaries[locale];

--- a/lib/i18n/get-dictionary.ts
+++ b/lib/i18n/get-dictionary.ts
@@ -1,0 +1,8 @@
+import 'server-only';
+
+import type { Locale } from './config';
+import { getDictionarySync } from './dictionaries';
+
+export async function getDictionary(locale: Locale) {
+  return getDictionarySync(locale);
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "harrison-associes",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "lucide-react": "^0.441.0",
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "sonner": "^1.5.0",
+    "tailwind-merge": "^2.5.2",
+    "tailwindcss-animate": "^1.0.7",
+    "@radix-ui/react-slot": "^1.0.4"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.66",
+    "@types/react-dom": "18.2.22",
+    "autoprefixer": "10.4.19",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.4",
+    "typescript": "5.4.5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,84 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --font-size: 16px;
+  --background: #ffffff;
+  --foreground: #333333;
+  --card: #ffffff;
+  --card-foreground: #333333;
+  --popover: #ffffff;
+  --popover-foreground: #333333;
+  --primary: #2c1810;
+  --primary-foreground: #ffffff;
+  --secondary: #f8f6f3;
+  --secondary-foreground: #2c1810;
+  --muted: #f8f6f3;
+  --muted-foreground: #8b7355;
+  --accent: #8b4513;
+  --accent-foreground: #ffffff;
+  --wood: #a0522d;
+  --wood-light: #d2b48c;
+  --wood-dark: #654321;
+  --destructive: #d4183d;
+  --destructive-foreground: #ffffff;
+  --border: rgba(44, 24, 16, 0.1);
+  --input: rgba(255, 255, 255, 0.6);
+  --ring: #8b4513;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+}
+
+.dark {
+  --background: #181818;
+  --foreground: #f5f5f5;
+  --card: #181818;
+  --card-foreground: #f5f5f5;
+  --popover: #181818;
+  --popover-foreground: #f5f5f5;
+  --primary: #f5f5f5;
+  --primary-foreground: #1a1a1a;
+  --secondary: #2a2a2a;
+  --secondary-foreground: #f5f5f5;
+  --muted: #2a2a2a;
+  --muted-foreground: #d1d1d1;
+  --accent: #f5f5f5;
+  --accent-foreground: #1a1a1a;
+  --destructive: #c53b4a;
+  --destructive-foreground: #ffffff;
+  --border: rgba(255, 255, 255, 0.1);
+  --input: rgba(40, 40, 40, 0.8);
+  --ring: #f5f5f5;
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground antialiased;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+    font-size: var(--font-size);
+    font-weight: 300;
+  }
+
+  ::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: #f8f6f3;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: #a0522d;
+    border-radius: 3px;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: #8b4513;
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,44 @@
+import type { Config } from 'tailwindcss';
+import { fontFamily } from 'tailwindcss/defaultTheme';
+
+const config: Config = {
+  darkMode: ['class'],
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './content/**/*.{md,mdx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+        primary: 'var(--primary)',
+        'primary-foreground': 'var(--primary-foreground)',
+        secondary: 'var(--secondary)',
+        'secondary-foreground': 'var(--secondary-foreground)',
+        accent: 'var(--accent)',
+        'accent-foreground': 'var(--accent-foreground)',
+        destructive: 'var(--destructive)',
+        'destructive-foreground': 'var(--destructive-foreground)',
+        border: 'var(--border)',
+        input: 'var(--input)',
+        ring: 'var(--ring)',
+        wood: 'var(--color-wood)',
+        'wood-light': 'var(--color-wood-light)',
+        'wood-dark': 'var(--color-wood-dark)'
+      },
+      borderRadius: {
+        lg: 'var(--radius-lg)',
+        md: 'var(--radius-md)',
+        sm: 'var(--radius-sm)'
+      },
+      fontFamily: {
+        sans: ['var(--font-inter)', ...fontFamily.sans]
+      }
+    }
+  },
+  plugins: [require('tailwindcss-animate')]
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,51 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2022"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "incremental": true,
+    "types": [
+      "node"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": [
+        "components/*"
+      ],
+      "@/lib/*": [
+        "lib/*"
+      ],
+      "@/styles/*": [
+        "styles/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- replace the locale-scoped app layout with a shared `(marketing)` layout and direct routes for the home, methodology, expertise, team, founder and contact pages
- update navigation and section components to use the new top-level URLs so calls-to-action work without locale prefixes
- remove the unused Next.js i18n config, drop the `next-intl` dependency and refresh the README to describe the simpler structure

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d96af039008320b4ebdeb09c21badf